### PR TITLE
Use upstream secp256k1.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,5 +11,4 @@ num-traits = "0.2"
 failure = "0.1"
 serde_bytes = "0.10"
 sha3 = "0.7"
-# TODO: Swap to 0.11 once new release is rolled up with my PR that fixes big endian support https://github.com/rust-bitcoin/rust-secp256k1/pull/64
-secp256k1 = { git = "https://github.com/rust-bitcoin/rust-secp256k1/", branch = "master" }
+secp256k1 = "0.11"

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -20,8 +20,7 @@ pub fn hex_str_to_bytes(s: &str) -> Result<Vec<u8>, ByteDecodeError> {
                 .and_then(|res| {
                     u8::from_str_radix(&res, 16).map_err(|e| ByteDecodeError::ParseError(e))
                 })
-        })
-        .collect()
+        }).collect()
 }
 
 #[test]


### PR DESCRIPTION
My patch is merged upstream and released to crates.io so its safe to use crates.io version.

Context: https://github.com/rust-bitcoin/rust-secp256k1/pull/64

Closes #15 