### PR TITLE
Run dummy transactions through Ganache.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,9 @@ env:
 before_install:
   - command -v cross 1>/dev/null || cargo install cross
 
+before_script:
+  - docker run -d -p 8545:8545 trufflesuite/ganache-cli:latest -a 10 -i 42 -e 1000 --debug
+
 script:
   - cross build --target $TARGET --verbose --all
   - cross test --target $TARGET --verbose --all

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,9 +22,6 @@ env:
 before_install:
   - command -v cross 1>/dev/null || cargo install cross
 
-before_script:
-  - docker run -d -p 8545:8545 trufflesuite/ganache-cli:latest -a 10 -i 42 -e 1000 --debug
-
 script:
   - cross build --target $TARGET --verbose --all
   - cross test --target $TARGET --verbose --all
@@ -34,12 +31,20 @@ matrix:
     - rust: nightly
   fast_finish: true
   include:
-    - rust: stable
-      ? env
-      ? before_install
-      script:
-        - rustup component add rustfmt-preview
-        - cargo fmt --all -- --check
+  - rust: stable
+    ? env
+    ? before_install
+    script:
+      - rustup component add rustfmt-preview
+      - cargo fmt --all -- --check
+  - rust: stable
+    env:
+    before_install:
+    before_script:
+    - docker run -d -p 8545:8545 trufflesuite/ganache-cli:latest -a 10 -i 42 -e 1000 --debug
+    script:
+    # Runs expensive testnet tests
+    - cargo test --verbose -- --ignored testnet
 
 deploy:
   # Create new crates.io package

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,13 @@ serde_derive = "1.0"
 name = "transaction_tests"
 harness = false
 
+[[test]]
+name = "testnet_tests"
+harness = false
+
 [dev-dependencies]
 rustc-test = "0.3.0"
 serde_json = "1.0"
 failure = "0.1"
+web3 = "0.4.0"
+rand = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "clarity"
 version = "0.1.2"
 authors = ["Michał Papierski <michal@papierski.net>"]
-autotests = false
+autotests = true
 include = [
     "**/*.rs",
     "Cargo.toml"
@@ -28,10 +28,6 @@ serde_derive = "1.0"
 
 [[test]]
 name = "transaction_tests"
-harness = false
-
-[[test]]
-name = "testnet_tests"
 harness = false
 
 [dev-dependencies]

--- a/src/private_key.rs
+++ b/src/private_key.rs
@@ -5,8 +5,7 @@ use secp256k1::{Message, PublicKey, Secp256k1, SecretKey};
 use sha3::{Digest, Keccak256};
 use signature::Signature;
 use std::str::FromStr;
-use utils::{hex_str_to_bytes, ByteDecodeError};
-// use secp256k1::{, RecoverableSignature, RecoveryId, Secp256k1, SecretKey};
+use utils::{bytes_to_hex_str, hex_str_to_bytes, ByteDecodeError};
 use types::BigEndianInt;
 
 #[derive(Fail, Debug, PartialEq)]
@@ -109,6 +108,12 @@ impl PrivateKey {
     pub fn sign_msg(&self, data: &[u8]) -> Signature {
         let digest = Keccak256::digest(data);
         self.sign_hash(&digest)
+    }
+}
+
+impl ToString for PrivateKey {
+    fn to_string(&self) -> String {
+        format!("0x{}", bytes_to_hex_str(&self.to_bytes()))
     }
 }
 

--- a/src/private_key.rs
+++ b/src/private_key.rs
@@ -5,8 +5,8 @@ use secp256k1::{Message, PublicKey, Secp256k1, SecretKey};
 use sha3::{Digest, Keccak256};
 use signature::Signature;
 use std::str::FromStr;
-use utils::{bytes_to_hex_str, hex_str_to_bytes, ByteDecodeError};
 use types::BigEndianInt;
+use utils::{bytes_to_hex_str, hex_str_to_bytes, ByteDecodeError};
 
 #[derive(Fail, Debug, PartialEq)]
 pub enum PrivateKeyError {

--- a/tests/testnet_tests.rs
+++ b/tests/testnet_tests.rs
@@ -1,0 +1,194 @@
+extern crate clarity;
+extern crate rand;
+extern crate rustc_test as test;
+extern crate web3;
+use clarity::utils::bytes_to_hex_str;
+use clarity::{PrivateKey, Transaction};
+use rand::{OsRng, Rng};
+use std::env;
+use std::fs::File;
+use std::io::Read;
+use std::path::Path;
+use std::{thread, time};
+use test::{DynTestFn, DynTestName, ShouldPanic, TestDesc, TestDescAndFn};
+use web3::api::Web3;
+use web3::futures::Future;
+use web3::helpers::{self, CallFuture};
+use web3::types::{Address, Bytes, TransactionRequest, U256};
+use web3::Transport;
+
+/// Creates a random key by reading random data from the available OS facility
+fn make_random_key() -> PrivateKey {
+    let mut rng = OsRng::new().unwrap();
+    let mut data = [0u8; 32];
+    rng.fill_bytes(&mut data);
+
+    let res = PrivateKey::from(data);
+    debug_assert_ne!(res, PrivateKey::new());
+    res
+}
+
+/// Test that makes bunch of transactions between Alice and Bob
+///
+/// Two private keys are created (Alice, Bob), and then a list of accounts is
+/// retrieved from the Ganache server, and then 10 ETH is sent to Alice.
+/// After that, Alice sends 5 transactions with 0.1ETH to Bob.
+///
+/// At the end there is verification how big the balance is on Alice, and how much
+/// Bob received.
+///
+/// This test tries assumes that localhost:8545 is the Ganache server. Easiest way
+/// to do it is to use Docker and execute:
+///
+/// docker run \
+///   -p 8545:8545 \
+///   trufflesuite/ganache-cli:latest \
+///   -a 10 \
+///   -i 42 \
+///   -e 1000 \
+///   --debug
+///
+/// Other parameters could be changed, but most important parameter is "-i 42" which sets
+/// the network ID to "42". This is very important as this test signs transactions for this
+/// network. Other values will make the test failing.
+///
+/// Additionally Ganache by default makes 10 accounts with 100 ETH each, so
+/// this test could be probably run few times on a single instance.
+fn alice_to_bob() {
+    let (_eloop, transport) = web3::transports::Http::new("http://localhost:8545").unwrap();
+    let web3 = Web3::new(transport);
+
+    let alice_priv_key = make_random_key();
+    println!("Alice private key: 0x{}", alice_priv_key.to_string());
+    let bob_priv_key = make_random_key();
+    assert_ne!(alice_priv_key, bob_priv_key);
+
+    println!("Bob private key: 0x{}", bob_priv_key.to_string());
+
+    let accounts = web3.eth().accounts().wait().unwrap();
+
+    let one_eth: U256 = "de0b6b3a7640000".parse().unwrap();
+
+    let seed = accounts.iter().nth(0).unwrap();
+    println!("Sending 10 ETH to Alice from {:?}", seed);
+    // Send 1 ETH to Alice from a first account from Ganache
+    let tx_req = TransactionRequest {
+        from: *seed,
+        to: Some(alice_priv_key.to_public_key().unwrap().as_bytes().into()),
+        gas: None,
+        gas_price: Some(0x1.into()),
+        value: Some(one_eth * 10u64),
+        data: None,
+        nonce: None,
+        condition: None,
+    };
+    let res = web3.eth().send_transaction(tx_req).wait().unwrap();
+    println!("Res {:?}", res);
+    let res = web3
+        .eth()
+        .balance(
+            alice_priv_key.to_public_key().unwrap().as_bytes().into(),
+            None,
+        ).wait()
+        .unwrap();
+
+    // assert_eq!("")
+    println!("Alice balance {:?}", res);
+    assert_eq!(res, one_eth * 10u64);
+
+    // Send 5 transactions using Clarity from Alice to Bob
+    for nonce in 0u64..5u64 {
+        let tx = Transaction {
+            nonce: nonce.into(),
+            gas_price: 1000000000u64.into(),
+            gas_limit: 21000u64.into(),
+            to: bob_priv_key.to_public_key().unwrap(),
+            value: 1_000_000_000_000_000_000u64.into(), // 0.1ETH
+            data: Vec::new(),
+            signature: None,
+        };
+        let signed_tx = tx.sign(&alice_priv_key, Some(42));
+        assert!(signed_tx.is_valid());
+        assert_eq!(
+            signed_tx.sender().unwrap(),
+            alice_priv_key.to_public_key().unwrap()
+        );
+        let res = web3
+            .eth()
+            .send_raw_transaction(Bytes::from(signed_tx.to_bytes().unwrap()))
+            .wait()
+            .unwrap();
+        println!(
+            "Tx {} Hash {:?} Our hash {:?}",
+            nonce,
+            res,
+            bytes_to_hex_str(&signed_tx.hash())
+        );
+    }
+    let res = web3
+        .eth()
+        .balance(
+            alice_priv_key.to_public_key().unwrap().as_bytes().into(),
+            None,
+        ).wait()
+        .unwrap();
+    println!("Alice balance {:?}", res);
+    assert_eq!(res, (one_eth * 5u64) - 2100u64 * 5u64 * 10000000000u64);
+    let res = web3
+        .eth()
+        .balance(
+            bob_priv_key.to_public_key().unwrap().as_bytes().into(),
+            None,
+        ).wait()
+        .unwrap();
+    println!("Bob balance {:?}", res);
+    assert_eq!(res, one_eth * 5u64);
+}
+
+/// This function verifies if a web3 transport can be safely created.
+fn can_make_web3() -> bool {
+    for counter in 0..30 {
+        match web3::transports::Http::new("http://localhost:8545") {
+            Ok((_evloop, transport)) => {
+                let web3 = Web3::new(transport);
+                match web3.eth().accounts().wait() {
+                    Ok(accounts) => return true,
+                    Err(e) => {
+                        println!("Unable to retrieve accounts ({}): {}", counter, e);
+                        thread::sleep(time::Duration::from_secs(1));
+                        continue;
+                    }
+                }
+
+                return true;
+            }
+            Err(e) => {
+                println!("Unable to create transport ({}): {}", counter, e);
+                thread::sleep(time::Duration::from_secs(1));
+                continue;
+            }
+        }
+    }
+    false
+}
+
+fn tests() -> Vec<TestDescAndFn> {
+    let mut desc = TestDesc::new(DynTestName("AliceAndBob".to_string()));
+
+    // This is very important bit: If a transport can't be constructed in ~30s then this test will be marked as ignored.
+    desc.ignore = !can_make_web3();
+
+    let mut test = TestDescAndFn {
+        desc: desc,
+        testfn: DynTestFn(Box::new(move || {
+            alice_to_bob();
+        })),
+    };
+
+    vec![test]
+}
+
+fn main() {
+    let args: Vec<_> = env::args().collect();
+    test::test_main(&args, tests());
+}


### PR DESCRIPTION
This will verify that the money is actually sent and accepted by a
testnet.

Of course this wouldn't replace real transactions on real network but it
verifies the behaviour in an environment that is close to the real
testnet/mainnet.

This is last change before focusing 100% on Guac as this tests automatically verifies transactions on Ganache testnet. This change works fine locally, but it wasn't that straightforward to put on travis because `cross` runs builds and tests in a container, and apparently you can't run and expose ganache-cli to `cross` containers.

# TODO

- [x] Change strategy from using test_c and conditionally ignoring, to ignoring by default, and adding a new build to the matrix which would run `cargo` instead of `cross`.
- [x] Verify on travis and ganache.