### PR TITLE
Implement missing traits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,13 +17,14 @@ travis-ci = { repository = "althea-mesh/clarity", branch = "master" }
 [dependencies]
 serde = "1.0"
 serde-rlp = "0.1"
-num-bigint = "0.2"
+num-bigint = { version = "0.2", default-features = false, features = ["serde"] }
 num-traits = "0.2"
 failure = "0.1"
 serde_bytes = "0.10"
 sha3 = "0.7"
 secp256k1 = "0.11"
 lazy_static = "1.1"
+serde_derive = "1.0"
 
 [[test]]
 name = "transaction_tests"
@@ -32,5 +33,4 @@ harness = false
 [dev-dependencies]
 rustc-test = "0.3.0"
 serde_json = "1.0"
-serde_derive = "1.0"
 failure = "0.1"

--- a/src/address.rs
+++ b/src/address.rs
@@ -5,7 +5,7 @@ use std::str::FromStr;
 use utils::bytes_to_hex_str;
 use utils::{hex_str_to_bytes, ByteDecodeError};
 /// This type represents ETH address
-#[derive(PartialEq, Debug, Clone)]
+#[derive(PartialEq, Debug, Clone, Eq, Hash)]
 pub struct Address {
     // TODO: address seems to be limited to 20 characters, but we keep it flexible
     data: Vec<u8>,
@@ -160,4 +160,19 @@ fn handle_prefixed() {
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x0b, 0x93, 0x31, 0x67, 0x7e, 0x6e, 0xbf
         ])
     );
+}
+
+#[test]
+fn hashed() {
+    // One of the use cases for Address could be a key in a HashMap to store some
+    // additional values per address.
+    use std::collections::HashMap;
+    let a = Address::from_str("0x000000000000000000000000000b9331677e6ebf").unwrap();
+    let b = Address::from_str("0x00000000000000000000000000000000deadbeef").unwrap();
+    let mut map = HashMap::new();
+    map.insert(a.clone(), "Foo");
+    map.insert(b.clone(), "Bar");
+
+    assert_eq!(map.get(&a).unwrap(), &"Foo");
+    assert_eq!(map.get(&b).unwrap(), &"Bar");
 }

--- a/src/address.rs
+++ b/src/address.rs
@@ -5,7 +5,7 @@ use std::str::FromStr;
 use utils::bytes_to_hex_str;
 use utils::{hex_str_to_bytes, ByteDecodeError};
 /// This type represents ETH address
-#[derive(PartialEq, Debug, Clone, Eq, PartialOrd, Hash)]
+#[derive(PartialEq, Debug, Clone, Eq, PartialOrd, Hash, Deserialize)]
 pub struct Address {
     // TODO: address seems to be limited to 20 characters, but we keep it flexible
     data: Vec<u8>,

--- a/src/address.rs
+++ b/src/address.rs
@@ -5,7 +5,7 @@ use std::str::FromStr;
 use utils::bytes_to_hex_str;
 use utils::{hex_str_to_bytes, ByteDecodeError};
 /// This type represents ETH address
-#[derive(PartialEq, Debug, Clone, Eq, Hash)]
+#[derive(PartialEq, Debug, Clone, Eq, PartialOrd, Hash)]
 pub struct Address {
     // TODO: address seems to be limited to 20 characters, but we keep it flexible
     data: Vec<u8>,
@@ -175,4 +175,18 @@ fn hashed() {
 
     assert_eq!(map.get(&a).unwrap(), &"Foo");
     assert_eq!(map.get(&b).unwrap(), &"Bar");
+}
+
+#[test]
+fn ordered() {
+    let a = Address::from_str("0x000000000000000000000000000000000000000a").unwrap();
+    let b = Address::from_str("0x000000000000000000000000000000000000000b").unwrap();
+    let c = Address::from_str("0x000000000000000000000000000000000000000c").unwrap();
+    assert!(c > b);
+    assert!(b > a);
+    assert!(b < c);
+    assert!(a < c);
+    assert_ne!(a, b);
+    assert_ne!(b, c);
+    assert_ne!(a, c);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,8 @@ extern crate secp256k1;
 extern crate sha3;
 #[macro_use]
 extern crate lazy_static;
+#[macro_use]
+extern crate serde_derive;
 
 pub mod address;
 pub mod constants;

--- a/src/private_key.rs
+++ b/src/private_key.rs
@@ -12,7 +12,7 @@ pub enum PrivateKeyError {
     InvalidLengthError,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Copy, Clone)]
 pub struct PrivateKey([u8; 32]);
 
 impl FromStr for PrivateKey {

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -7,7 +7,7 @@ use serde::Serialize;
 use serde::Serializer;
 use types::BigEndianInt;
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Signature {
     pub v: BigEndianInt,
     pub r: BigEndianInt,

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -7,7 +7,7 @@ use serde::Serialize;
 use serde::Serializer;
 use types::BigEndianInt;
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Signature {
     pub v: BigEndianInt,
     pub r: BigEndianInt,

--- a/src/types.rs
+++ b/src/types.rs
@@ -11,7 +11,7 @@ use std::ops::{Add, AddAssign};
 use std::str::FromStr;
 
 /// A wrapper for BigUint which provides serialization to BigEndian in radix 16
-#[derive(PartialEq, Eq, PartialOrd, Clone)]
+#[derive(PartialEq, Eq, PartialOrd, Clone, Deserialize)]
 pub struct BigEndianInt(BigUint);
 
 impl Zero for BigEndianInt {

--- a/src/types.rs
+++ b/src/types.rs
@@ -173,6 +173,15 @@ impl<'a> From<&'a [u8]> for BigEndianInt {
     }
 }
 
+impl Into<[u8; 32]> for BigEndianInt {
+    fn into(self) -> [u8; 32] {
+        let bytes = self.0.to_bytes_be();
+        let mut res = [0u8; 32];
+        res[32 - bytes.len()..].copy_from_slice(&bytes);
+        res
+    }
+}
+
 impl fmt::Debug for BigEndianInt {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.0.to_str_radix(10))
@@ -223,4 +232,16 @@ fn clone() {
     let a = BigEndianInt::zero();
     let b = a.clone();
     assert_eq!(a, b);
+}
+
+#[test]
+fn into_array_of_32_bytes() {
+    let bytes: [u8; 32] = BigEndianInt::from(1024u64).into();
+    assert_eq!(
+        bytes,
+        [
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 4, 0
+        ]
+    );
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -194,6 +194,12 @@ impl Into<[u8; 32]> for BigEndianInt {
     }
 }
 
+impl Into<BigUint> for BigEndianInt {
+    fn into(self) -> BigUint {
+        self.0
+    }
+}
+
 impl fmt::Debug for BigEndianInt {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.0.to_str_radix(10))
@@ -264,4 +270,12 @@ fn into_array_of_32_bytes() {
             0, 4, 0
         ]
     );
+}
+
+#[test]
+fn extract() {
+    use num_traits::One;
+    let one = BigEndianInt::from(1u8);
+    let big_uint: BigUint = one.into();
+    assert_eq!(big_uint, BigUint::one());
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -11,7 +11,7 @@ use std::ops::{Add, AddAssign};
 use std::str::FromStr;
 
 /// A wrapper for BigUint which provides serialization to BigEndian in radix 16
-#[derive(PartialEq, PartialOrd, Clone)]
+#[derive(PartialEq, Eq, PartialOrd, Clone)]
 pub struct BigEndianInt(BigUint);
 
 impl Zero for BigEndianInt {

--- a/src/types.rs
+++ b/src/types.rs
@@ -155,6 +155,18 @@ impl FromStr for BigEndianInt {
     }
 }
 
+impl From<u8> for BigEndianInt {
+    fn from(v: u8) -> Self {
+        BigEndianInt(BigUint::from(v))
+    }
+}
+
+impl From<u16> for BigEndianInt {
+    fn from(v: u16) -> Self {
+        BigEndianInt(BigUint::from(v))
+    }
+}
+
 impl From<u32> for BigEndianInt {
     fn from(v: u32) -> Self {
         BigEndianInt(BigUint::from(v))
@@ -202,6 +214,14 @@ fn serialize() {
             255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 254,
         ]
     );
+}
+
+#[test]
+fn from_unsigned() {
+    let _a = BigEndianInt::from(1u8);
+    let _b = BigEndianInt::from(2u16);
+    let _c = BigEndianInt::from(3u32);
+    let _d = BigEndianInt::from(4u64);
 }
 
 #[test]

--- a/src/types.rs
+++ b/src/types.rs
@@ -200,6 +200,12 @@ impl Into<BigUint> for BigEndianInt {
     }
 }
 
+impl From<BigUint> for BigEndianInt {
+    fn from(v: BigUint) -> BigEndianInt {
+        BigEndianInt(v)
+    }
+}
+
 impl fmt::Debug for BigEndianInt {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.0.to_str_radix(10))
@@ -278,4 +284,12 @@ fn extract() {
     let one = BigEndianInt::from(1u8);
     let big_uint: BigUint = one.into();
     assert_eq!(big_uint, BigUint::one());
+}
+
+#[test]
+fn construct() {
+    use num_traits::One;
+    let one = BigUint::one();
+    let big_uint: BigEndianInt = one.into();
+    assert_eq!(big_uint, 1u32.into());
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -11,7 +11,7 @@ use std::ops::{Add, AddAssign};
 use std::str::FromStr;
 
 /// A wrapper for BigUint which provides serialization to BigEndian in radix 16
-#[derive(PartialEq, Eq, PartialOrd, Clone, Deserialize)]
+#[derive(PartialEq, Eq, PartialOrd, Clone, Deserialize, Hash)]
 pub struct BigEndianInt(BigUint);
 
 impl Zero for BigEndianInt {


### PR DESCRIPTION
This way an Address could be easily stored in a HashMap, and much more since the guac_rs relies heavily on Parity code and Parity code is rich in helpers, and traits that we didn't know yet.

Closes #23 