### PR TITLE
Added a method to sign arbitrary hashes.

### DIFF
--- a/src/signature.rs
+++ b/src/signature.rs
@@ -85,13 +85,11 @@ impl ToString for Signature {
         wtr.extend(&s);
 
         let v = self.v.to_bytes_be();
-        println!("vlen {}", v.len());
         wtr.extend(&v[v.len() - 1..]);
 
         let mut result = "0x".to_owned();
         result += &bytes_to_hex_str(&wtr);
         result
-        // format!("0x{:64x}{:64x}{:02x}", self.r, self.s, self.v)
     }
 }
 


### PR DESCRIPTION
This is required as contract calls often needs signed hashes of data.

**NOTE** The resulting signature when signing arbitrary hashes doesn't adjust the "v" value with `network_id` settings. Not yet certain if it makes sense in this case. Would Solidity verify arbitrary signatures against its network id?