### PR TITLE
Docs

### DIFF
--- a/src/abi.rs
+++ b/src/abi.rs
@@ -12,8 +12,10 @@
 //!
 //! ## Limitation
 //!
-//! Currently deeply nested data structures are not guaranteed to work.
+//! Currently this module can only serialize types that can be represented by a [Token](#struct.Token).
 //!
+//! Unfortunately if you need to support custom type that is not currently supported you are welcome to open an issue [on issues page](https://github.com/althea-mesh/clarity/issues/new),
+//! or do the serialization yourself by converting your custom type into a `[u8; 32]` array and creating a proper Token instance.
 use address::Address;
 use num256::Uint256;
 use sha3::{Digest, Keccak256};

--- a/src/abi.rs
+++ b/src/abi.rs
@@ -1,17 +1,16 @@
+//! A module to simplify ABI encoding
+//!
+//! For simplicity, it is based on tokens. You have to specify a list of
+//! tokens and they will be automatically encoded.
+//!
+//! Additionally there are helpers to help deal with deriving a function
+//! signatures.
+//!
+//! This is not a full fledged implemementation of ABI encoder, it is more
+//! like a bunch of helpers that would help to successfuly encode a contract
+//! call.
+//!
 use address::Address;
-
-/// A module to simplify ABI encoding
-///
-/// For simplicity, it is based on tokens. You have to specify a list of
-/// tokens and they will be automatically encoded.
-///
-/// Additionally there are helpers to help deal with deriving a function
-/// signatures.
-///
-/// This is not a full fledged implemementation of ABI encoder, it is more
-/// like a bunch of helpers that would help to successfuly encode a contract
-/// call.
-///
 use num256::Uint256;
 use sha3::{Digest, Keccak256};
 use types::BigEndianInt;

--- a/src/address.rs
+++ b/src/address.rs
@@ -6,7 +6,11 @@ use std::str;
 use std::str::FromStr;
 use utils::bytes_to_hex_str;
 use utils::{hex_str_to_bytes, ByteDecodeError};
-/// This type represents ETH address
+
+/// Representation of an Ethereum address.
+///
+/// Address is usually derived from a `PrivateKey`, or converted from its
+/// textual representation back to a binary form.
 #[derive(PartialEq, Debug, Clone, Eq, PartialOrd, Hash, Deserialize)]
 pub struct Address {
     // TODO: address seems to be limited to 20 characters, but we keep it flexible
@@ -29,16 +33,23 @@ impl Serialize for Address {
 }
 
 impl Address {
+    /// Creates new `Address` filled with zeros.
+    ///
+    /// The actual implementation of this doesn't really
+    /// creates the zeros. In our case we treat it as "empty"
+    /// address, which is then reperesented by zeros.
     pub fn new() -> Address {
         Address { data: Vec::new() }
     }
 
+    /// Get raw bytes of the address.
     pub fn as_bytes(&self) -> &[u8] {
         &self.data
     }
 }
 
 impl Default for Address {
+    /// Construct a default `Address` filled with zeros.
     fn default() -> Address {
         Address { data: Vec::new() }
     }
@@ -115,6 +126,24 @@ impl From<ByteDecodeError> for AddressError {
 impl FromStr for Address {
     type Err = AddressError;
 
+    /// Parses a string into a valid Ethereum address.
+    ///
+    /// # Supported formats
+    ///
+    /// * `0x` prefixed address
+    /// * Raw bytes of an address represented by a bytes as an hexadecimal.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use std::str::FromStr;
+    /// use clarity::Address;
+    /// // Method 1
+    /// Address::from_str("0x0102030405060708090a0b0c0d0e0f1011121314").unwrap();
+    /// // Method 1 (without 0x prefix)
+    /// Address::from_str("0102030405060708090a0b0c0d0e0f1011121314").unwrap();
+    /// // Method 2
+    /// let _address : Address = "14131211100f0e0d0c0b0a090807060504030201".parse().unwrap();
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         if s.len() == 0 {
             return Ok(Address::default());
@@ -131,6 +160,15 @@ impl FromStr for Address {
 }
 
 impl ToString for Address {
+    /// Creates a textual representation of the `Address`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use clarity::Address;
+    /// let address = Address::default();
+    /// address.to_string(); // 0x0000000000000000000000000000000000000000
+    /// ```
     fn to_string(&self) -> String {
         bytes_to_hex_str(&self.data)
     }

--- a/src/address.rs
+++ b/src/address.rs
@@ -10,7 +10,7 @@ use utils::{hex_str_to_bytes, ByteDecodeError};
 /// Representation of an Ethereum address.
 ///
 /// Address is usually derived from a `PrivateKey`, or converted from its
-/// textual representation back to a binary form.
+/// textual representation.
 #[derive(PartialEq, Debug, Clone, Eq, PartialOrd, Hash, Deserialize)]
 pub struct Address {
     // TODO: address seems to be limited to 20 characters, but we keep it flexible

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,7 @@
-use failure::Error;
-
+/// Custom error implementation that describes possible
+/// error states.
+///
+/// This is shared by a whole crate.
 #[derive(Fail, Debug)]
 pub enum ClarityError {
     #[fail(display = "Invalid network id")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,24 @@
+//! # Introduction
+//! Clarity is a low level library designed to handle Ethereum transactions.
+//!
+//! You can create, sign, verify transactions, as well as work with contract calls, and encode ABI.
+//! It is designed with embedded devices on mind so big/little endian architectures and 32/64 bits are supported.
+//!
+//! # Features
+//!
+//! * Supports both little endian and big endian
+//! * Works well on both 32 and 64 bit architectures
+//! * Handle private keys
+//! * Create public keys
+//! * Sign transactions
+//! * Verify transaction
+//! * Handle signatures
+//! * Encode ABI for contract calls
+//!
+//! # Documentation
+//!
+//! * [GitHub repository](https://github.com/althea-mesh/clarity)
+//! * [Cargo package](https://crates.io/crates/clarity)
 extern crate num_bigint;
 extern crate num_traits;
 extern crate serde;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 //! You can create, sign, verify transactions, as well as work with contract calls, and encode ABI.
 //! It is designed with embedded devices on mind so big/little endian architectures and 32/64 bits are supported.
 //!
-//! # Features
+//! ## Features
 //!
 //! * Supports both little endian and big endian
 //! * Works well on both 32 and 64 bit architectures
@@ -15,7 +15,7 @@
 //! * Handle signatures
 //! * Encode ABI for contract calls
 //!
-//! # Documentation
+//! ## Documentation
 //!
 //! * [GitHub repository](https://github.com/althea-mesh/clarity)
 //! * [Cargo package](https://crates.io/crates/clarity)

--- a/src/private_key.rs
+++ b/src/private_key.rs
@@ -14,12 +14,25 @@ pub enum PrivateKeyError {
     InvalidLengthError,
 }
 
+/// Representation of an Ethereum private key.
+///
+/// Private key can be created using a textual representation,
+/// a raw binary form using array of bytes.
+///
+/// With PrivateKey you are able to sign messages, derive
+/// public keys. Cryptography-related methods use
+/// SECP256K1 elliptic curves.
 #[derive(Debug, PartialEq, Copy, Clone)]
 pub struct PrivateKey([u8; 32]);
 
 impl FromStr for PrivateKey {
     type Err = Error;
 
+    /// Parse a textual representation of a private key back into PrivateKey type.
+    ///
+    /// It has to be a string that represents 64 characters that are hexadecimal
+    /// representation of 32 bytes. Optionally this string can be prefixed with `0x`
+    /// at the beggining.
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         if s.len() != 64 {
             return Err(PrivateKeyError::InvalidLengthError.into());
@@ -39,10 +52,16 @@ impl From<[u8; 32]> for PrivateKey {
 }
 
 impl PrivateKey {
+    /// Creates a null private key that uses zeros.
     pub fn new() -> PrivateKey {
         PrivateKey([0u8; 32])
     }
 
+    /// Convert a given slice of bytes into a valid private key.
+    ///
+    /// Input bytes are validated for a length only.
+    ///
+    /// * `slice` - A slice of raw bytes with a length of 32.
     pub fn from_slice(slice: &[u8]) -> Result<PrivateKey, Error> {
         if slice.len() != 32 {
             return Err(ClarityError::InvalidPrivKey.into());
@@ -52,13 +71,22 @@ impl PrivateKey {
         Ok(PrivateKey(res))
     }
 
+    /// Get bytes back from a PrivateKey
     pub fn to_bytes(&self) -> [u8; 32] {
         self.0
     }
 
-    /// Given a private key it generates a valid public key.
+    /// Create a public key for a given private key.
     ///
-    /// This is well explained in the EthereumYellow Paper Appendix F.
+    /// This is well explained in the Ethereum Yellow Paper Appendix F.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use clarity::PrivateKey;
+    /// let private_key = PrivateKey::new();
+    /// let public_key = private_key.to_public_key().unwrap();
+    /// ```
     pub fn to_public_key(&self) -> Result<Address, Error> {
         let secp256k1 = Secp256k1::new();
         let sk = SecretKey::from_slice(&secp256k1, &self.0)?;
@@ -112,6 +140,7 @@ impl PrivateKey {
 }
 
 impl ToString for PrivateKey {
+    /// Converts PrivateKey into a textual representation.
     fn to_string(&self) -> String {
         format!("0x{}", bytes_to_hex_str(&self.to_bytes()))
     }

--- a/src/private_key.rs
+++ b/src/private_key.rs
@@ -84,7 +84,7 @@ impl PrivateKey {
     ///
     /// ```rust
     /// use clarity::PrivateKey;
-    /// let private_key = PrivateKey::new();
+    /// let private_key : PrivateKey = "0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f1e".parse().unwrap();
     /// let public_key = private_key.to_public_key().unwrap();
     /// ```
     pub fn to_public_key(&self) -> Result<Address, Error> {


### PR DESCRIPTION
Added more comments with more usage examples. 

TODO:

- [x] Figure out proper structure as for which methods panic (there is a special sections for that in rustdoc/markdown). More examples perhaps.
- [x] Add proper and example codes in `lib.rs` with `# How to use` section
- [x] Now this is interesting - code examples are runnable so example could also serve as a test. It should be added to build process with `cargo test --doc`,

Open questions:

- Does rustdoc allow for easy linking? I.e. instead of saying `Something something PrivateKey` maybe there could be a link `Something something [PrivateKey](struct.PrivateKey)`
