### PR TITLE
Add a de counterpart for big_endian_int_serialize

### DIFF
--- a/src/signature.rs
+++ b/src/signature.rs
@@ -6,16 +6,24 @@ use num_traits::Zero;
 use serde::ser::SerializeTuple;
 use serde::Serialize;
 use serde::Serializer;
-use utils::big_endian_int_serialize;
-use utils::bytes_to_hex_str;
+use utils::{big_endian_uint256_deserialize, big_endian_uint256_serialize, bytes_to_hex_str};
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Signature {
-    #[serde(serialize_with = "big_endian_int_serialize")]
+    #[serde(
+        serialize_with = "big_endian_uint256_serialize",
+        deserialize_with = "big_endian_uint256_deserialize"
+    )]
     pub v: Uint256,
-    #[serde(serialize_with = "big_endian_int_serialize")]
+    #[serde(
+        serialize_with = "big_endian_uint256_serialize",
+        deserialize_with = "big_endian_uint256_deserialize"
+    )]
     pub r: Uint256,
-    #[serde(serialize_with = "big_endian_int_serialize")]
+    #[serde(
+        serialize_with = "big_endian_uint256_serialize",
+        deserialize_with = "big_endian_uint256_deserialize"
+    )]
     pub s: Uint256,
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -2,14 +2,20 @@ use num256::Uint256;
 use num_traits::Zero;
 use serde::Serialize;
 use serde::Serializer;
-use utils::big_endian_int_serialize;
+use utils::{big_endian_uint256_deserialize, big_endian_uint256_serialize};
 
 /// A thin wrapper type to change the way Uint256 is serialized.
 ///
 /// This is done this way to overcome the "orphan rule" where you can't
 /// implement traits for a type that comes from different crate.
-#[derive(Serialize)]
-pub struct BigEndianInt(#[serde(serialize_with = "big_endian_int_serialize")] pub Uint256);
+#[derive(Serialize, Deserialize)]
+pub struct BigEndianInt(
+    #[serde(
+        serialize_with = "big_endian_uint256_serialize",
+        deserialize_with = "big_endian_uint256_deserialize"
+    )]
+    pub Uint256,
+);
 
 #[test]
 fn serialize() {


### PR DESCRIPTION
src/utils.rs:
* Rename big_endian_int_serialize -> big_endian_uint256_serialize to
reflect it using Uint256; also move it up so it's above the tests
* Add big_endian_uint256_deserialize to for doing reversing what
[...]_serialize does

src/signature.rs:
src/types.rs:
* Reflect above changes