### PR TITLE
Serialize/deserialize Address as string.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,6 +75,7 @@ pub mod constants;
 pub mod error;
 pub mod opcodes;
 pub mod private_key;
+mod rlp;
 mod signature;
 pub mod transaction;
 pub mod types;

--- a/src/private_key.rs
+++ b/src/private_key.rs
@@ -106,7 +106,7 @@ impl PrivateKey {
         // Finally an address is last 20 bytes of a hash of the public key.
         let sender = Keccak256::digest(&pkey[1..]);
         debug_assert_eq!(sender.len(), 32);
-        Ok(Address::from(&sender[12..]))
+        Address::from_slice(&sender[12..])
     }
     /// Signs any message that is represented by a data buffer
     pub fn sign_hash(&self, data: &[u8]) -> Signature {

--- a/src/rlp.rs
+++ b/src/rlp.rs
@@ -1,0 +1,43 @@
+//! A module that defines how types serialize into RLP.
+//!
+//! This module is left as private as this is considered a implementation detail
+//! of Clarity without any intention to be available outside.
+//!
+//! RLP encoder requires a binary data to be encoded in a well specified method.
+use address::Address;
+use serde::Serialize;
+use serde::Serializer;
+
+pub(crate) struct AddressDef<'a>(pub(crate) &'a Address);
+
+impl<'a> Serialize for AddressDef<'a> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        if *self.0 == Address::default() {
+            // If the address is empty we can serialize it as empty value
+            serializer.serialize_bytes(&[])
+        } else {
+            // Here we serialize all bytes
+            serializer.serialize_bytes(&self.0.as_bytes())
+        }
+    }
+}
+
+#[test]
+fn serialize_null_address() {
+    use serde_rlp::ser::to_bytes;
+    let address = Address::new();
+    assert_eq!(to_bytes(&AddressDef(&address)).unwrap(), [128]);
+}
+
+#[test]
+fn serialize_padded_address() {
+    use serde_rlp::ser::to_bytes;
+    let address: Address = "00000000000000000000000000000000000000c0".parse().unwrap();
+    assert_eq!(
+        to_bytes(&AddressDef(&address)).unwrap(),
+        [148, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xc0]
+    );
+}

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -10,6 +10,7 @@ use opcodes::GTXCOST;
 use opcodes::GTXDATANONZERO;
 use opcodes::GTXDATAZERO;
 use private_key::PrivateKey;
+use rlp::AddressDef;
 use secp256k1::{Message, RecoverableSignature, RecoveryId, Secp256k1, SecretKey};
 use serde::ser::SerializeTuple;
 use serde::Serialize;
@@ -45,7 +46,7 @@ impl Serialize for Transaction {
             &BigEndianInt(self.nonce.clone()),
             &BigEndianInt(self.gas_price.clone()),
             &BigEndianInt(self.gas_limit.clone()),
-            &self.to,
+            &AddressDef(&self.to),
             &BigEndianInt(self.value.clone()),
             &ByteBuf::from(self.data.clone()),
             &BigEndianInt(sig.v.clone()),
@@ -89,7 +90,7 @@ impl Transaction {
             &BigEndianInt(self.nonce.clone()),
             &BigEndianInt(self.gas_price.clone()),
             &BigEndianInt(self.gas_limit.clone()),
-            &self.to,
+            &AddressDef(&self.to),
             &BigEndianInt(self.value.clone()),
             &ByteBuf::from(self.data.clone()),
         );
@@ -102,7 +103,7 @@ impl Transaction {
             &BigEndianInt(self.nonce.clone()),
             &BigEndianInt(self.gas_price.clone()),
             &BigEndianInt(self.gas_limit.clone()),
-            &self.to,
+            &AddressDef(&self.to),
             &BigEndianInt(self.value.clone()),
             &ByteBuf::from(self.data.clone()),
             &BigEndianInt(network_id.clone()),
@@ -206,7 +207,7 @@ impl Transaction {
             // Finally an address is last 20 bytes of a hash of the public key.
             let sender = Keccak256::digest(&pkey[1..]);
             debug_assert_eq!(sender.len(), 32);
-            return Ok(Address::from(&sender[12..]));
+            Address::from_slice(&sender[12..])
         }
     }
     /// Creates a hash of a transaction given all TX attributes

--- a/tests/transaction_tests.rs
+++ b/tests/transaction_tests.rs
@@ -174,7 +174,7 @@ fn test_fn(fixtures: &TestFixture, filler: &TestFiller, expect: Option<&TestFill
         nonce: (&*data[0]).into(),
         gas_price: (&*data[1]).into(),
         gas_limit: (&*data[2]).into(),
-        to: (&*data[3]).into(),
+        to: Address::from_slice(&*data[3]).unwrap_or(Address::default()),
         value: (&*data[4]).into(),
         data: (&*data[5]).into(),
         signature: Some(Signature::new(


### PR DESCRIPTION
This hides binary serialization in "rlp" module and hides it to outside
world as implementation detail. Public interface exposes only string for
user convenience.

As a consequence it also changes data layout of Address to a fixed size
array (which should be done in the first place).

Closes #55.