### PR TITLE
Clippy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,14 @@ matrix:
     script:
       - rustup component add rustfmt-preview
       - cargo fmt --all -- --check
+  - name: Clippy
+    rust: stable
+    ? env
+    ? before_install
+    before_script:
+      - rustup component add clippy-preview
+    script:
+      - cargo clippy --all-targets --all-features -- -D warnings
   - rust: stable
     env:
     before_install:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ secp256k1 = "0.11"
 lazy_static = "1.1"
 serde_derive = "1.0"
 num256 = "0.1"
+bytecount = "0.4"
 
 [[test]]
 name = "transaction_tests"

--- a/src/abi.rs
+++ b/src/abi.rs
@@ -69,13 +69,6 @@ impl SerializedToken {
             _ => None,
         }
     }
-    /// Gets a reference to value held by Dynamic
-    fn as_dynamic_ref(&self) -> Option<&Vec<u8>> {
-        match *self {
-            SerializedToken::Dynamic(ref data) => Some(&data),
-            _ => None,
-        }
-    }
 }
 
 impl Token {
@@ -212,7 +205,7 @@ impl<'a> From<&'a str> for Token {
 
 impl From<Uint256> for Token {
     fn from(v: Uint256) -> Token {
-        Token::Uint(v.into())
+        Token::Uint(v)
     }
 }
 
@@ -295,7 +288,7 @@ pub fn encode_tokens(tokens: &[Token]) -> Vec<u8> {
     // A cache of dynamic data buffers that are stored here.
     let mut dynamic_data: Vec<Vec<u8>> = Vec::new();
 
-    for ref token in tokens.iter() {
+    for token in tokens.iter() {
         match token.serialize() {
             SerializedToken::Static(data) => res.extend(&data),
             SerializedToken::Dynamic(data) => {
@@ -325,7 +318,8 @@ pub fn encode_tokens(tokens: &[Token]) -> Vec<u8> {
     // Concat all the dynamic data buffers at the end of the process
     // All the offsets are calculated while iterating and properly stored
     // in a single pass.
-    for ref data in dynamic_data.iter() {
+    // let valuse = &dynamic_data.iter();
+    for data in dynamic_data.iter() {
         res.extend(&data[..]);
     }
     res
@@ -387,7 +381,7 @@ fn encode_f() {
     let result = encode_tokens(&[
         0x123u32.into(),
         vec![0x456u32, 0x789u32].into(),
-        Token::Bytes("1234567890".as_bytes().to_vec()),
+        Token::Bytes(b"1234567890".to_vec()),
         "Hello, world!".into(),
     ]);
     assert!(result.len() % 8 == 0);
@@ -416,8 +410,8 @@ fn encode_f_with_real_unbounded_bytes() {
     let result = encode_tokens(&[
         0x123u32.into(),
         vec![0x456u32, 0x789u32].into(),
-        Token::Bytes("1234567890".as_bytes().to_vec()),
-        "Hello, world!".as_bytes().to_vec().into(),
+        Token::Bytes(b"1234567890".to_vec()),
+        b"Hello, world!".to_vec().into(),
     ]);
     assert!(result.len() % 8 == 0);
     assert_eq!(

--- a/src/address.rs
+++ b/src/address.rs
@@ -13,19 +13,10 @@ use utils::{hex_str_to_bytes, ByteDecodeError};
 ///
 /// Address is usually derived from a `PrivateKey`, or converted from its
 /// textual representation.
-#[derive(PartialEq, Debug, Clone, Copy, Eq, PartialOrd, Ord, Hash)]
+#[derive(PartialEq, Debug, Clone, Copy, Eq, PartialOrd, Ord, Hash, Default)]
 pub struct Address([u8; 20]);
 
 impl Address {
-    /// Creates new `Address` filled with zeros.
-    ///
-    /// The actual implementation of this doesn't really
-    /// creates the zeros. In our case we treat it as "empty"
-    /// address, which is then reperesented by zeros.
-    pub fn new() -> Address {
-        Address([0; 20])
-    }
-
     /// Get raw bytes of the address.
     pub fn as_bytes(&self) -> &[u8] {
         &self.0
@@ -43,13 +34,6 @@ impl Address {
         let mut result: [u8; 20] = Default::default();
         result.copy_from_slice(&data);
         Ok(Address(result))
-    }
-}
-
-impl Default for Address {
-    /// Construct a default `Address` filled with zeros.
-    fn default() -> Address {
-        Address([0; 20])
     }
 }
 
@@ -218,7 +202,7 @@ fn decode() {
 
 #[test]
 fn serialize_null_address() {
-    let address = Address::new();
+    let address = Address::default();
     let s = serde_json::to_string(&address).unwrap();
     assert_eq!(s, r#""0x0000000000000000000000000000000000000000""#);
     let recovered_addr: Address = serde_json::from_str(&s).unwrap();

--- a/src/address.rs
+++ b/src/address.rs
@@ -97,7 +97,7 @@ impl fmt::LowerHex for Address {
                 return res;
             }
         }
-        return Ok(());
+        Ok(())
     }
 }
 
@@ -116,7 +116,7 @@ impl fmt::UpperHex for Address {
                 return res;
             }
         }
-        return Ok(());
+        Ok(())
     }
 }
 
@@ -160,7 +160,7 @@ impl FromStr for Address {
     /// // Method 2
     /// let _address : Address = "14131211100f0e0d0c0b0a090807060504030201".parse().unwrap();
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        if s.len() == 0 {
+        if s.is_empty() {
             return Ok(Address::default());
         }
         let s = if s.starts_with("0x") { &s[2..] } else { &s };
@@ -263,11 +263,11 @@ fn hashed() {
     let a = Address::from_str("0x000000000000000000000000000b9331677e6ebf").unwrap();
     let b = Address::from_str("0x00000000000000000000000000000000deadbeef").unwrap();
     let mut map = HashMap::new();
-    map.insert(a.clone(), "Foo");
-    map.insert(b.clone(), "Bar");
+    map.insert(a, "Foo");
+    map.insert(b, "Bar");
 
-    assert_eq!(map.get(&a).unwrap(), &"Foo");
-    assert_eq!(map.get(&b).unwrap(), &"Bar");
+    assert_eq!(&map[&a], &"Foo");
+    assert_eq!(&map[&b], &"Bar");
 }
 
 #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,6 +67,7 @@ extern crate sha3;
 extern crate lazy_static;
 #[macro_use]
 extern crate serde_derive;
+extern crate bytecount;
 extern crate num256;
 
 pub mod abi;

--- a/src/opcodes.rs
+++ b/src/opcodes.rs
@@ -41,5 +41,5 @@ pub const GMODEXPQUADDIVISOR: u32 = 20;
 pub const GECADD: u32 = 500;
 pub const GECMUL: u32 = 40000;
 
-pub const GPAIRINGBASE: u32 = 100000;
+pub const GPAIRINGBASE: u32 = 100_000;
 pub const GPAIRINGPERPOINT: u32 = 80000;

--- a/src/private_key.rs
+++ b/src/private_key.rs
@@ -27,7 +27,7 @@ pub enum PrivateKeyError {
 /// With PrivateKey you are able to sign messages, derive
 /// public keys. Cryptography-related methods use
 /// SECP256K1 elliptic curves.
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Copy, Clone)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Copy, Clone, Default)]
 pub struct PrivateKey([u8; 32]);
 
 impl FromStr for PrivateKey {
@@ -59,11 +59,6 @@ impl From<[u8; 32]> for PrivateKey {
 }
 
 impl PrivateKey {
-    /// Creates a null private key that uses zeros.
-    pub fn new() -> PrivateKey {
-        PrivateKey([0u8; 32])
-    }
-
     /// Convert a given slice of bytes into a valid private key.
     ///
     /// Input bytes are validated for a length only.
@@ -308,7 +303,7 @@ fn parse_address_2() {
 #[should_panic]
 fn zero_address() {
     // A key full of zeros is an invalid private key.
-    let key = PrivateKey::new();
+    let key = PrivateKey::default();
     key.to_public_key().unwrap();
 }
 
@@ -360,7 +355,7 @@ fn sign_message() {
         ]
     );
 
-    let hash = Keccak256::digest(&"Hello, world!".as_bytes());
+    let hash = Keccak256::digest(b"Hello, world!");
 
     // geth account import <(echo c87f65ff3f271bf5dc8643484f66b200109caffe4bf98c4cb393dc35740b28c0)
     let sig = key.sign_hash(&hash);
@@ -378,7 +373,7 @@ fn sign_message() {
             .unwrap()
     );
 
-    let sig_2 = key.sign_msg(&"Hello, world!".as_bytes());
+    let sig_2 = key.sign_msg(b"Hello, world!");
     assert_eq!(sig, sig_2);
 }
 

--- a/src/rlp.rs
+++ b/src/rlp.rs
@@ -28,7 +28,7 @@ impl<'a> Serialize for AddressDef<'a> {
 #[test]
 fn serialize_null_address() {
     use serde_rlp::ser::to_bytes;
-    let address = Address::new();
+    let address = Address::default();
     assert_eq!(to_bytes(&AddressDef(&address)).unwrap(), [128]);
 }
 

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -278,7 +278,7 @@ fn test_vitaliks_eip_158_vitalik_12_json() {
         nonce: Uint256::from_str_radix("0e", 16).unwrap(),
         gas_price: Uint256::from_str_radix("00", 16).unwrap(),
         gas_limit: Uint256::from_str_radix("0493e0", 16).unwrap(),
-        to: Address::new(), // "" - zeros only
+        to: Address::default(), // "" - zeros only
         value: Uint256::from_str_radix("00", 16).unwrap(),
         data: hex_str_to_bytes("60f2ff61000080610011600039610011565b6000f3").unwrap(),
         signature: Some(Signature::new(
@@ -378,7 +378,7 @@ fn test_basictests_txtest_2() {
         nonce: "0".parse().unwrap(),
         gas_price: "1000000000000".parse().unwrap(),
         gas_limit: "10000".parse().unwrap(),
-        to: Address::new(),
+        to: Address::default(),
         value: "0".parse().unwrap(),
         data: hex_str_to_bytes("6025515b525b600a37f260003556601b596020356000355760015b525b54602052f260255860005b525b54602052f2").unwrap(),
         signature: None

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -89,7 +89,7 @@ impl Serialize for Transaction {
     {
         // Serialization of a transaction without signature serializes
         // the data assuming the "vrs" params are set to 0.
-        let sig = self.signature.clone().unwrap_or(Signature::default());
+        let sig = self.signature.clone().unwrap_or_default();
         let data = (
             &BigEndianInt(self.nonce.clone()),
             &BigEndianInt(self.gas_price.clone()),
@@ -124,7 +124,7 @@ impl Transaction {
     }
 
     pub fn intrinsic_gas_used(&self) -> Uint256 {
-        let num_zero_bytes = self.data.iter().filter(|&&b| b == 0u8).count();
+        let num_zero_bytes = bytecount::count(&self.data, 0u8);
         let num_non_zero_bytes = self.data.len() - num_zero_bytes;
         Uint256::from(GTXCOST)
             + Uint256::from(GTXDATAZERO) * Uint256::from(num_zero_bytes as u32)
@@ -144,7 +144,7 @@ impl Transaction {
         );
         to_bytes(&data).unwrap()
     }
-    fn to_unsigned_tx_params_for_network(&self, network_id: Uint256) -> Vec<u8> {
+    fn to_unsigned_tx_params_for_network(&self, network_id: &Uint256) -> Vec<u8> {
         // assert!(self.signature.is_none());
         // TODO: Could be refactored in a better way somehow
         let data = (
@@ -165,8 +165,8 @@ impl Transaction {
         // This is a special matcher to prepare raw RLP data with correct network_id.
         let rlpdata = match network_id {
             Some(network_id) => {
-                assert!(1 <= network_id && network_id < 9223372036854775790u64); // 1 <= id < 2**63 - 18
-                self.to_unsigned_tx_params_for_network(network_id.into())
+                assert!(1 <= network_id && network_id < 9_223_372_036_854_775_790u64); // 1 <= id < 2**63 - 18
+                self.to_unsigned_tx_params_for_network(&network_id.into())
             }
             None => self.to_unsigned_tx_params(),
         };
@@ -192,7 +192,7 @@ impl Transaction {
         let sig = self.signature.as_ref().unwrap();
         // Zero RS also mean the resulting address is "null"
         if sig.r == Uint256::zero() && sig.s == Uint256::zero() {
-            return Ok(Address::from([0xffu8; 20]));
+            Ok(Address::from([0xffu8; 20]))
         } else {
             let (vee, sighash) = if sig.v == 27u32.into() || sig.v == 28u32.into() {
                 // Valid V values are in {27, 28} according to Ethereum Yellow paper Appendix F (282).
@@ -207,7 +207,7 @@ impl Transaction {
                 assert!(vee == 27u32.into() || vee == 28u32.into());
                 // In this case hash of the transaction is usual RLP paremeters but "VRS" params
                 // are swapped for [network_id, '', '']. See Appendix F (285)
-                let rlp_data = self.to_unsigned_tx_params_for_network(network_id.clone());
+                let rlp_data = self.to_unsigned_tx_params_for_network(&network_id);
                 let sighash = Keccak256::digest(&rlp_data);
                 (vee, sighash)
             } else {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -111,10 +111,10 @@ pub fn bytes_to_hex_str(bytes: &[u8]) -> String {
 
 #[test]
 fn encode_bytes() {
-    assert_eq!(bytes_to_hex_str(&vec![0xf]), "0f".to_owned());
-    assert_eq!(bytes_to_hex_str(&vec![0xff]), "ff".to_owned());
+    assert_eq!(bytes_to_hex_str(&[0xf]), "0f".to_owned());
+    assert_eq!(bytes_to_hex_str(&[0xff]), "ff".to_owned());
     assert_eq!(
-        bytes_to_hex_str(&vec![0xde, 0xad, 0xbe, 0xef]),
+        bytes_to_hex_str(&[0xde, 0xad, 0xbe, 0xef]),
         "deadbeef".to_owned()
     );
 }

--- a/tests/testnet_tests.rs
+++ b/tests/testnet_tests.rs
@@ -17,7 +17,7 @@ fn make_random_key() -> PrivateKey {
     rng.fill_bytes(&mut data);
 
     let res = PrivateKey::from(data);
-    debug_assert_ne!(res, PrivateKey::new());
+    debug_assert_ne!(res, PrivateKey::default());
     res
 }
 
@@ -26,7 +26,7 @@ fn make_web3() -> Option<(
     web3::transports::EventLoopHandle,
     Web3<web3::transports::Http>,
 )> {
-    let address = env::var("GANACHE_HOST").unwrap_or("http://localhost:8545".to_owned());
+    let address = env::var("GANACHE_HOST").unwrap_or_else(|_| "http://localhost:8545".to_string());
     eprintln!("Trying to create a Web3 connection to {:?}", address);
     for counter in 0..30 {
         match web3::transports::Http::new(&address) {
@@ -101,7 +101,7 @@ fn testnet_alice_and_bob() {
 
     let one_eth: U256 = "de0b6b3a7640000".parse().unwrap();
 
-    let seed = accounts.iter().nth(0).unwrap();
+    let seed = &accounts[0];
     println!("Sending 10 ETH to Alice from {:?}", seed);
     // Send 1 ETH to Alice from a first account from Ganache
     let tx_req = TransactionRequest {
@@ -132,7 +132,7 @@ fn testnet_alice_and_bob() {
     for nonce in 0u64..5u64 {
         let tx = Transaction {
             nonce: nonce.into(),
-            gas_price: 1000000000u64.into(),
+            gas_price: 1_000_000_000u64.into(),
             gas_limit: 21000u64.into(),
             to: bob_priv_key.to_public_key().unwrap(),
             value: 1_000_000_000_000_000_000u64.into(), // 0.1ETH
@@ -165,7 +165,7 @@ fn testnet_alice_and_bob() {
         ).wait()
         .unwrap();
     println!("Alice balance {:?}", res);
-    assert_eq!(res, (one_eth * 5u64) - 2100u64 * 5u64 * 10000000000u64);
+    assert_eq!(res, (one_eth * 5u64) - 2100u64 * 5u64 * 10_000_000_000u64);
     let res = web3
         .eth()
         .balance(


### PR DESCRIPTION
A lot of warnings raised by clippy and also a lot of interesting lessons:

- Use `unwrap_or_default` instead of `unwrap_or(Foo::default())`
- Use `unwrap_or_else` if your `unwrap_or(...)` expression has function calls. This should make the function calls lazy
- (Obviously) `b"foo"` instead of `"foo".as_bytes()`
- No need for `vec.iter().nth(0).unwrap()` when you can just do `&accounts[0]`.

Also:

- Clippy is added as another build on travis to ensure no regressions
- No warnings whatsoever (this used to happen a lot)

Etc.

Also this resolves #57 and resolves #43 in a way that `new()` is removed and `Default` trait is implemented instead for those structures. This was also mentioned by clippy (i.e. if you have new() that does default initialization you want to change it to use `Default` trait instead which could be just derived for convenience)

Closes #61 