### PR TITLE
Benchmarking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,12 @@ matrix:
       - rustup component add clippy-preview
     script:
       - cargo clippy --all-targets --all-features -- -D warnings
+  - name: Benchmark
+    rust: stable
+    ? env
+    ? before_install
+    script:
+      - cargo bench
   - rust: stable
     env:
     before_install:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,5 +42,5 @@ web3 = "0.4.0"
 criterion = "0.2"
 
 [[bench]]
-name = "transaction_bench"
+name = "crypto_bench"
 harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,3 +39,8 @@ rand = "0.3"
 rustc-test = "0.3.0"
 serde_json = "1.0"
 web3 = "0.4.0"
+criterion = "0.2"
+
+[[bench]]
+name = "transaction_bench"
+harness = false

--- a/benches/crypto_bench.rs
+++ b/benches/crypto_bench.rs
@@ -19,8 +19,17 @@ fn tx_sign_bench(c: &mut Criterion) {
         data: Vec::new(),
         signature: None,
     };
+
+    let signed_tx = tx.clone().sign(&key, None);
+
     c.bench_function("sign tx without network id", move |b| {
         b.iter(|| tx.sign(&key, None))
+    });
+
+    c.bench_function("recover sender", move |b| {
+        b.iter(|| {
+            signed_tx.sender().unwrap();
+        })
     });
 }
 

--- a/benches/crypto_bench.rs
+++ b/benches/crypto_bench.rs
@@ -24,5 +24,15 @@ fn tx_sign_bench(c: &mut Criterion) {
     });
 }
 
-criterion_group!(benches, tx_sign_bench);
+fn private_key_to_public(c: &mut Criterion) {
+    let key: PrivateKey = "0102010201020102010201020102010201020102010201020102010201020102"
+        .parse()
+        .unwrap();
+
+    c.bench_function("private key to public", move |b| {
+        b.iter(|| key.to_public_key().unwrap())
+    });
+}
+
+criterion_group!(benches, tx_sign_bench, private_key_to_public);
 criterion_main!(benches);

--- a/benches/transaction_bench.rs
+++ b/benches/transaction_bench.rs
@@ -5,7 +5,6 @@ extern crate num256;
 
 use clarity::{PrivateKey, Transaction};
 use criterion::Criterion;
-use num256::Uint256;
 
 fn tx_sign_bench(c: &mut Criterion) {
     let key: PrivateKey = "c87f65ff3f271bf5dc8643484f66b200109caffe4bf98c4cb393dc35740b28c0"

--- a/benches/transaction_bench.rs
+++ b/benches/transaction_bench.rs
@@ -7,14 +7,6 @@ use clarity::{PrivateKey, Transaction};
 use criterion::Criterion;
 use num256::Uint256;
 
-fn fibonacci(n: u64) -> u64 {
-    match n {
-        0 => 1,
-        1 => 1,
-        n => fibonacci(n - 1) + fibonacci(n - 2),
-    }
-}
-
 fn tx_sign_bench(c: &mut Criterion) {
     let key: PrivateKey = "c87f65ff3f271bf5dc8643484f66b200109caffe4bf98c4cb393dc35740b28c0"
         .parse()

--- a/benches/transaction_bench.rs
+++ b/benches/transaction_bench.rs
@@ -1,0 +1,37 @@
+#[macro_use]
+extern crate criterion;
+extern crate clarity;
+extern crate num256;
+
+use clarity::{PrivateKey, Transaction};
+use criterion::Criterion;
+use num256::Uint256;
+
+fn fibonacci(n: u64) -> u64 {
+    match n {
+        0 => 1,
+        1 => 1,
+        n => fibonacci(n - 1) + fibonacci(n - 2),
+    }
+}
+
+fn tx_sign_bench(c: &mut Criterion) {
+    let key: PrivateKey = "c87f65ff3f271bf5dc8643484f66b200109caffe4bf98c4cb393dc35740b28c0"
+        .parse()
+        .unwrap();
+    let tx = Transaction {
+        nonce: 0.into(),
+        gas_price: "1000000000000".parse().unwrap(),
+        gas_limit: "10000".parse().unwrap(),
+        to: "13978aee95f38490e9769c39b2773ed763d9cd5f".parse().unwrap(),
+        value: "10000000000000000".parse().unwrap(),
+        data: Vec::new(),
+        signature: None,
+    };
+    c.bench_function("sign tx without network id", move |b| {
+        b.iter(|| tx.sign(&key, None))
+    });
+}
+
+criterion_group!(benches, tx_sign_bench);
+criterion_main!(benches);

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,0 +1,12 @@
+//! Global context of Secp256k1
+//!
+//! Its kept as thread local for performance benefits. So it would be initialized
+//! on first use.
+//!
+//!
+use secp256k1::{All, Secp256k1};
+use std::cell::RefCell;
+
+thread_local!{
+    pub(crate) static SECP256K1: RefCell<Secp256k1<All>> = RefCell::new(Secp256k1::new());
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,6 +73,7 @@ extern crate num256;
 pub mod abi;
 pub mod address;
 pub mod constants;
+mod context;
 pub mod error;
 pub mod opcodes;
 pub mod private_key;

--- a/src/private_key.rs
+++ b/src/private_key.rs
@@ -3,7 +3,7 @@ use context::SECP256K1;
 use error::ClarityError;
 use failure::Error;
 use num256::Uint256;
-use secp256k1::{Message, PublicKey, Secp256k1, SecretKey};
+use secp256k1::{Message, PublicKey, SecretKey};
 use serde::Deserialize;
 use serde::Deserializer;
 use serde::Serialize;
@@ -103,7 +103,7 @@ impl PrivateKey {
         })?;
         // TODO: This part is duplicated with sender code.
         assert_eq!(pkey.len(), 65);
-        if &pkey[1..] == &[0x00u8; 64][..] {
+        if pkey[1..] == [0x00u8; 64][..] {
             return Err(ClarityError::ZeroPrivKey.into());
         }
         // Finally an address is last 20 bytes of a hash of the public key.

--- a/src/private_key.rs
+++ b/src/private_key.rs
@@ -3,7 +3,7 @@ use context::SECP256K1;
 use error::ClarityError;
 use failure::Error;
 use num256::Uint256;
-use secp256k1::{All, Message, PublicKey, Secp256k1, SecretKey};
+use secp256k1::{Message, PublicKey, Secp256k1, SecretKey};
 use serde::Deserialize;
 use serde::Deserializer;
 use serde::Serialize;

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -12,7 +12,7 @@ use opcodes::GTXDATANONZERO;
 use opcodes::GTXDATAZERO;
 use private_key::PrivateKey;
 use rlp::AddressDef;
-use secp256k1::{Message, RecoverableSignature, RecoveryId, Secp256k1};
+use secp256k1::{Message, RecoverableSignature, RecoveryId};
 use serde::Serialize;
 use serde::Serializer;
 use serde_bytes::ByteBuf;


### PR DESCRIPTION
As @jkilpatr noticed there is huge performance impact when sending transactions often. So this simple code does some benchmarking and with this simple change the performance has greatly improved.

Turns out we should reuse Secp256k1 context everywhere in clarity.

Before reusing context:

```
        sign tx without network id
                                time:   [14.749 ms 14.999 ms 15.247 ms]
        Found 7 outliers among 100 measurements (7.00%)
          6 (6.00%) high mild
          1 (1.00%) high severe
```

After reusing context:

```
        sign tx without network id
                                time:   [84.839 us 85.273 us 85.801 us]
                                change: [-99.412% -99.403% -99.393%] (p = 0.00 < 0.05)
                                Performance has improved.
    
```

99.4% improvement

Closes #20 