### PR TITLE
Added ability to recover any signed messages.

### DIFF
--- a/src/private_key.rs
+++ b/src/private_key.rs
@@ -388,6 +388,15 @@ fn sign_message() {
 
     let sig_2 = key.sign_msg(b"Hello, world!");
     assert_eq!(sig, sig_2);
+
+    // Recover address using just a signature
+    let recovered = sig
+        .recover(&hash)
+        .expect("Unable to recover address from a signature");
+    assert_eq!(
+        recovered,
+        key.to_public_key().expect("Unable to get address")
+    );
 }
 
 #[test]


### PR DESCRIPTION
This adds `Signature.verify` which works on arbitrary signed messages (hashes)

- `Transaction` now is refactored to use `Signature.verify` internally for a given TX hash
- `Signature.verify` works on any arbitrary signed messages

There is a room for improvement when creating compact signatures, where `Into` for `[u8; 32]` on `Uint256` requires a given number to be cloned. See althea-mesh/num256_rs#15

Closes #72.